### PR TITLE
Add blur parameter for afterimages

### DIFF
--- a/docs/AfterImage.md
+++ b/docs/AfterImage.md
@@ -1,0 +1,7 @@
+# AfterImage State Controller
+
+The `AfterImage` state controller now supports an optional `blur` parameter. When set to a value greater than zero, each recorded afterimage will render with a simple blur applied on the GPU.
+
+## Parameters
+
+- `blur` – integer value controlling the blur radius. Use `0` to disable the effect.

--- a/src/anim.go
+++ b/src/anim.go
@@ -683,7 +683,7 @@ func (a *Animation) drawSub1(angle, facing float32) (h, v, agl float32) {
 
 func (a *Animation) Draw(window *[4]int32, x, y, xcs, ycs, xs, xbs, ys,
 	rxadd float32, rot Rotation, rcx float32, pfx *PalFX, old bool, facing float32,
-	airOffsetFix [2]float32, projectionMode int32, fLength float32, color uint32, isReflection bool) {
+	airOffsetFix [2]float32, projectionMode int32, fLength float32, blur float32, color uint32, isReflection bool) {
 
 	// Skip blank animations
 	if a == nil || a.isBlank() {
@@ -781,13 +781,14 @@ func (a *Animation) Draw(window *[4]int32, x, y, xcs, ycs, xs, xbs, ys,
 		fLength:        fLength * sys.heightScale,
 		xOffset:        xoff * sys.widthScale,
 		yOffset:        yoff * sys.heightScale,
+		blur:           blur,
 	}
 
 	RenderSprite(rp)
 }
 
 func (a *Animation) ShadowDraw(window *[4]int32, x, y, xscl, yscl, vscl, rxadd float32, rot Rotation,
-	pfx *PalFX, old bool, color uint32, alpha int32, facing float32, airOffsetFix [2]float32, projectionMode int32, fLength float32) {
+	pfx *PalFX, old bool, blur float32, color uint32, alpha int32, facing float32, airOffsetFix [2]float32, projectionMode int32, fLength float32) {
 
 	// Skip blank shadows
 	if a == nil || a.isBlank() {
@@ -834,6 +835,7 @@ func (a *Animation) ShadowDraw(window *[4]int32, x, y, xscl, yscl, vscl, rxadd f
 		fLength:        fLength,
 		xOffset:        xoff,
 		yOffset:        yoff,
+		blur:           blur,
 	}
 
 	// TODO: This is redundant now that rp.tint is used to colorise the shadow
@@ -943,6 +945,7 @@ type SprData struct {
 	fLength      float32
 	window       [4]float32
 	xshear       float32
+	blur         float32
 }
 
 func (sd *SprData) isBlank() bool {
@@ -1030,7 +1033,7 @@ func (dl DrawList) draw(cameraX, cameraY, cameraScl float32) {
 
 		s.anim.Draw(drawwindow, pos[0]-xsoffset, pos[1], cs, cs, s.scl[0], s.scl[0],
 			s.scl[1], xshear, s.rot, float32(sys.gameWidth)/2, s.fx, s.oldVer, s.facing,
-			s.airOffsetFix, s.projection, s.fLength, 0, false)
+			s.airOffsetFix, s.projection, s.fLength, s.blur, 0, false)
 
 		sys.brightness = ob
 	}
@@ -1234,7 +1237,7 @@ func (sl ShadowList) draw(x, y, scl float32) {
 			sys.cam.GroundLevel()+(sys.cam.Offset[1]-es[1])-y-(s.pos[1]*yscale-offsetY)*scl,
 			scl*s.scl[0], scl*-s.scl[1],
 			yscale, xshear, rot,
-			s.fx, s.oldVer, uint32(color), intensity, s.facing, s.airOffsetFix, projection, fLength)
+			s.fx, s.oldVer, s.blur, uint32(color), intensity, s.facing, s.airOffsetFix, projection, fLength)
 	}
 }
 
@@ -1388,7 +1391,7 @@ func (sl ShadowList) drawReflection(x, y, scl float32) {
 			(sys.cam.GroundLevel()+sys.cam.Offset[1]-es[1])/scl-y/scl-(s.pos[1]*yscale-offsetY),
 			scl, scl, s.scl[0], s.scl[0],
 			-s.scl[1]*yscale, xshear, rot, float32(sys.gameWidth)/2,
-			s.fx, s.oldVer, s.facing, s.airOffsetFix, projection, fLength, color, true)
+			s.fx, s.oldVer, s.facing, s.airOffsetFix, projection, fLength, s.blur, color, true)
 	}
 }
 
@@ -1459,7 +1462,7 @@ func (a *Anim) Draw() {
 	if !sys.frameSkip {
 		a.anim.Draw(&a.window, a.x+float32(sys.gameWidth-320)/2,
 			a.y+float32(sys.gameHeight-240), 1, 1, a.xscl, a.xscl, a.yscl,
-			0, Rotation{}, 0, a.palfx, false, 1, [2]float32{1, 1}, 0, 0, 0, false)
+			0, Rotation{}, 0, a.palfx, false, 1, [2]float32{1, 1}, 0, 0, 0, 0, false)
 	}
 }
 

--- a/src/bytecode.go
+++ b/src/bytecode.go
@@ -6499,6 +6499,7 @@ const (
 	afterImage_palpostbright
 	afterImage_paladd
 	afterImage_palmul
+	afterImage_blur
 	afterImage_ignorehitpause
 	afterImage_last = iota + palFX_last + 1 - 1
 	afterImage_redirectid
@@ -6575,6 +6576,8 @@ func (sc afterImage) runSub(c *Char, ai *AfterImage, paramID byte, exp []Bytecod
 				ai.mul[2] = exp[2].evalF(c)
 			}
 		}
+	case afterImage_blur:
+		ai.blur = exp[0].evalI(c)
 	case afterImage_ignorehitpause:
 		ai.ignorehitpause = exp[0].evalB(c)
 	}

--- a/src/char.go
+++ b/src/char.go
@@ -201,7 +201,7 @@ func (cr ClsnRect) draw(trans int32) {
 			sys.clsnSpr.Tex, paltex, sys.clsnSpr.Size,
 			-c[0] * sys.widthScale, -c[1] * sys.heightScale, notiling,
 			c[2] * sys.widthScale, c[2] * sys.widthScale, c[3] * sys.heightScale, 1, 0,
-			1, 1, Rotation{c[6], 0, 0}, 0, trans, -1, nil, &sys.scrrect, c[4], c[5], 0, 0, 0, 0,
+			1, 1, Rotation{c[6], 0, 0}, 0, trans, -1, nil, &sys.scrrect, c[4], c[5], 0, 0, 0, 0, 0,
 		}
 		RenderSprite(params)
 	}
@@ -1013,6 +1013,7 @@ type AfterImage struct {
 	mul            [3]float32
 	timegap        int32
 	framegap       int32
+	blur           int32
 	alpha          [2]int32
 	palfx          []PalFX
 	imgs           [64]aimgImage
@@ -1029,6 +1030,7 @@ func newAfterImage() *AfterImage {
 	for i := range ai.palfx {
 		ai.palfx[i].enable, ai.palfx[i].negType = true, true
 	}
+	ai.blur = 0
 	ai.clear()
 	return ai
 }
@@ -1055,6 +1057,7 @@ func (ai *AfterImage) clear() {
 	ai.reccount = 0
 	ai.timecount = 0
 	ai.ignorehitpause = true
+	ai.blur = 0
 }
 
 func (ai *AfterImage) setPalColor(color int32) {
@@ -1221,6 +1224,7 @@ func (ai *AfterImage) recAndCue(sd *SprData, rec bool, hitpause bool, layer int3
 				fLength:      img.fLength,
 				window:       sd.window,
 				xshear:       sd.xshear,
+				blur:         float32(ai.blur),
 			})
 			// Afterimages don't cast shadows or reflections
 		}
@@ -1603,6 +1607,7 @@ func (e *Explod) update(oldVer bool, playerNo int) {
 		fLength:      fLength,
 		window:       ewin,
 		xshear:       xshear,
+		blur:         0,
 	}
 	sprs.add(sd)
 
@@ -2243,6 +2248,7 @@ func (p *Projectile) cueDraw(oldVer bool) {
 			fLength:      fLength,
 			window:       pwin,
 			xshear:       p.xshear,
+			blur:         0,
 		}
 		p.aimg.recAndCue(sd, sys.tickNextFrame() && notpause, false, p.layerno)
 		sprs.add(sd)
@@ -10276,6 +10282,7 @@ func (c *Char) cueDraw() {
 			fLength:      fLength,
 			xshear:       c.xshear,
 			window:       cwin,
+			blur:         0,
 		}
 		if !c.csf(CSF_trans) {
 			sd.alpha[0] = -1

--- a/src/common.go
+++ b/src/common.go
@@ -1007,7 +1007,7 @@ func (l *Layout) DrawAnim(r *[4]int32, x, y, scl, xscl, yscl float32, ln int16, 
 		a.Draw(r, x+l.offset[0]-xsoffset, y+l.offset[1]+float32(sys.gameHeight-240),
 			scl, scl, (l.scale[0]*xscl)*float32(l.facing), (l.scale[0]*xscl)*float32(l.facing),
 			(l.scale[1]*yscl)*float32(l.vfacing), xshear, Rotation{l.angle, 0, 0},
-			float32(sys.gameWidth-320)/2, palfx, false, 1, [2]float32{1, 1}, 0, 0, 0, false)
+			float32(sys.gameWidth-320)/2, palfx, false, 1, [2]float32{1, 1}, 0, 0, 0, 0, false)
 	}
 }
 

--- a/src/compiler_functions.go
+++ b/src/compiler_functions.go
@@ -1463,6 +1463,10 @@ func (c *Compiler) afterImageSub(is IniSection,
 		afterImage_framegap, VT_Int, 1, false); err != nil {
 		return err
 	}
+	if err := c.paramValue(is, sc, prefix+"blur",
+		afterImage_blur, VT_Int, 1, false); err != nil {
+		return err
+	}
 	if err := c.paramValue(is, sc, prefix+"palcolor",
 		afterImage_palcolor, VT_Int, 1, false); err != nil {
 		return err

--- a/src/font.go
+++ b/src/font.go
@@ -559,6 +559,7 @@ func (f *Fnt) DrawText(txt string, x, y, xscl, yscl, rxadd float32, rot Rotation
 		fLength:        0,
 		xOffset:        0,
 		yOffset:        0,
+		blur:           0,
 	}
 
 	for _, c := range txt {

--- a/src/image.go
+++ b/src/image.go
@@ -1249,6 +1249,7 @@ func (s *Sprite) Draw(x, y, xscale, yscale float32, rxadd float32, rot Rotation,
 		fLength:        0,
 		xOffset:        -xscale * float32(s.Offset[0]),
 		yOffset:        -yscale * float32(s.Offset[1]),
+		blur:           0,
 	}
 	RenderSprite(rp)
 }

--- a/src/render.go
+++ b/src/render.go
@@ -172,6 +172,7 @@ type RenderParams struct {
 	fLength        float32 // Focal length
 	xOffset        float32
 	yOffset        float32
+	blur           float32
 }
 
 func (rp *RenderParams) IsValid() bool {
@@ -462,6 +463,7 @@ func RenderSprite(rp RenderParams) {
 		gfx.SetUniformFv("mult", pmul[:])
 		gfx.SetUniformFv("tint", tint[:])
 		gfx.SetUniformF("alpha", a)
+		gfx.SetUniformF("blur", rp.blur)
 
 		rmTileSub(modelview, rp)
 

--- a/src/render_gl.go
+++ b/src/render_gl.go
@@ -455,7 +455,7 @@ func (r *Renderer_GL21) Init() {
 	r.spriteShader, _ = r.newShaderProgram(vertShader, fragShader, "", "Main Shader", true)
 	r.spriteShader.RegisterAttributes("position", "uv")
 	r.spriteShader.RegisterUniforms("modelview", "projection", "x1x2x4x3",
-		"alpha", "tint", "mask", "neg", "gray", "add", "mult", "isFlat", "isRgba", "isTrapez", "hue")
+		"alpha", "tint", "mask", "neg", "gray", "add", "mult", "isFlat", "isRgba", "isTrapez", "hue", "blur")
 	r.spriteShader.RegisterTextures("pal", "tex")
 	if r.enableModel {
 		if err := r.InitModelShader(); err != nil {

--- a/src/render_gl_gl32.go
+++ b/src/render_gl_gl32.go
@@ -459,7 +459,7 @@ func (r *Renderer_GL32) Init() {
 	r.spriteShader, _ = r.newShaderProgram(vertShader, fragShader, "", "Main Shader", true)
 	r.spriteShader.RegisterAttributes("position", "uv")
 	r.spriteShader.RegisterUniforms("modelview", "projection", "x1x2x4x3",
-		"alpha", "tint", "mask", "neg", "gray", "add", "mult", "isFlat", "isRgba", "isTrapez", "hue")
+		"alpha", "tint", "mask", "neg", "gray", "add", "mult", "isFlat", "isRgba", "isTrapez", "hue", "blur")
 	r.spriteShader.RegisterTextures("pal", "tex")
 
 	if r.enableModel {

--- a/src/render_kinc.go
+++ b/src/render_kinc.go
@@ -222,7 +222,7 @@ func (r *Renderer) SetPipeline(eq BlendEquation, src, dst BlendFunc) {
 		p.u = make(map[string]C.kinc_g4_constant_location_t)
 		p.t = make(map[string]C.kinc_g4_texture_unit_t)
 		p.RegisterUniforms("modelview", "projection", "x1x2x4x3",
-			"alpha", "tint", "mask", "neg", "gray", "add", "mult", "isFlat", "isRgba", "isTrapez", "hue")
+			"alpha", "tint", "mask", "neg", "gray", "add", "mult", "isFlat", "isRgba", "isTrapez", "hue", "blur")
 		p.RegisterTextures("pal", "tex")
 
 		r.pipelineCache[params] = p

--- a/src/shaders/sprite.frag.glsl
+++ b/src/shaders/sprite.frag.glsl
@@ -18,6 +18,7 @@ uniform vec3 add, mult;
 uniform float alpha, gray, hue;
 uniform int mask;
 uniform bool isFlat, isRgba, isTrapez, neg;
+uniform float blur;
 
 COMPAT_VARYING vec2 texcoord;
 
@@ -31,46 +32,66 @@ vec3 hue_shift(vec3 color, float dhue) {
 	) + dot(vec3(0.299, 0.587, 0.114), color) * (1.0 - c);
 }
 
+vec4 fetchColor(vec2 coord) {
+       vec4 c = COMPAT_TEXTURE(tex, coord);
+       if (!isRgba) {
+               c = COMPAT_TEXTURE(pal, vec2(c.r*0.9966, 0.5));
+       }
+       return c;
+}
+
 void main(void) {
-	if (isFlat) {
-		FragColor = tint;
-	} else {
-		vec2 uv = texcoord;
-		if (isTrapez) {
-			// Compute left/right trapezoid bounds at height uv.y
-			vec2 bounds = mix(x1x2x4x3.zw, x1x2x4x3.xy, uv.y);
-			// Correct uv.x from the fragment position on that segment
-			uv.x = (gl_FragCoord.x - bounds[0]) / (bounds[1] - bounds[0]);
-		}
+        if (isFlat) {
+                FragColor = tint;
+        } else {
+                vec2 uv = texcoord;
+                if (isTrapez) {
+                        // Compute left/right trapezoid bounds at height uv.y
+                        vec2 bounds = mix(x1x2x4x3.zw, x1x2x4x3.xy, uv.y);
+                        // Correct uv.x from the fragment position on that segment
+                        uv.x = (gl_FragCoord.x - bounds[0]) / (bounds[1] - bounds[0]);
+                }
 
-		vec4 c = COMPAT_TEXTURE(tex, uv);
-		vec3 neg_base = vec3(1.0);
-		vec3 final_add = add;
-		vec4 final_mul = vec4(mult, alpha);
-		if (isRgba) {
-			if (mask == -1) {
-				c.a = 1.0;
-			}
-			// RGBA sprites use premultiplied alpha for transparency	
-			neg_base *= c.a;
-			final_add *= c.a;
-			final_mul.rgb *= alpha;
-		} else {
-			c = COMPAT_TEXTURE(pal, vec2(c.r*0.9966, 0.5));
-			if (mask == -1) {
-				c.a = 1.0;
-			}
-		}
-		if (hue != 0) {
-			c.rgb = hue_shift(c.rgb,hue);			
-		}
-		if (neg) c.rgb = neg_base - c.rgb;
-		c.rgb = mix(c.rgb, vec3((c.r + c.g + c.b) / 3.0), gray) + final_add;
-		c *= final_mul;
+               vec4 c = fetchColor(uv);
+               if (blur > 0.0) {
+                       vec2 step;
+#if __VERSION__ >= 130
+                       step = blur / vec2(textureSize(tex, 0));
+#else
+                       step = blur / vec2(512.0, 512.0);
+#endif
+                       c += fetchColor(uv + vec2(step.x, 0.0));
+                       c += fetchColor(uv - vec2(step.x, 0.0));
+                       c += fetchColor(uv + vec2(0.0, step.y));
+                       c += fetchColor(uv - vec2(0.0, step.y));
+                       c /= 5.0;
+               }
+               vec3 neg_base = vec3(1.0);
+               vec3 final_add = add;
+               vec4 final_mul = vec4(mult, alpha);
+               if (isRgba) {
+                       if (mask == -1) {
+                               c.a = 1.0;
+                       }
+                       // RGBA sprites use premultiplied alpha for transparency
+                       neg_base *= c.a;
+                       final_add *= c.a;
+                       final_mul.rgb *= alpha;
+               } else {
+                       if (mask == -1) {
+                               c.a = 1.0;
+                       }
+               }
+               if (hue != 0) {
+                       c.rgb = hue_shift(c.rgb,hue);
+               }
+               if (neg) c.rgb = neg_base - c.rgb;
+               c.rgb = mix(c.rgb, vec3((c.r + c.g + c.b) / 3.0), gray) + final_add;
+               c *= final_mul;
 
-		// Add a final tint (used for shadows); make sure the result has premultiplied alpha
-		c.rgb = mix(c.rgb, tint.rgb * c.a, tint.a);
+               // Add a final tint (used for shadows); make sure the result has premultiplied alpha
+               c.rgb = mix(c.rgb, tint.rgb * c.a, tint.a);
 
-		FragColor = c;
-	}
+               FragColor = c;
+       }
 }

--- a/src/stage.go
+++ b/src/stage.go
@@ -527,7 +527,7 @@ func (bg backGround) draw(pos [2]float32, drawscl, bgscl, stglscl float32,
 			bg.xscale[0]*bgscl*(bg.scalestart[0]+xs)*xs3,
 			xbs*bgscl*(bg.scalestart[0]+xs)*xs3,
 			ys*ys3, xras*x/(AbsF(ys*ys3)*lscl[1]*float32(bg.anim.spr.Size[1])*bg.scalestart[1])*sclx_recip*bg.scalestart[1]-bg.xshear,
-			bg.rot, float32(sys.gameWidth)/2, bg.palfx, true, 1, [2]float32{1, 1}, int32(bg.projection), bg.fLength, 0, false)
+			bg.rot, float32(sys.gameWidth)/2, bg.palfx, true, 1, [2]float32{1, 1}, int32(bg.projection), bg.fLength, 0, 0, false)
 	}
 }
 

--- a/src/system.go
+++ b/src/system.go
@@ -1756,6 +1756,7 @@ func (s *System) action() {
 			projection:   0,
 			fLength:      0,
 			window:       [4]float32{0, 0, 0, 0},
+			blur:         0,
 		})
 		if s.superanim.loopend {
 			s.superanim = nil // Not allowed to loop


### PR DESCRIPTION
## Summary
- add blur support to AfterImage state controller and render pipeline
- expose blur value to shaders and implement sprite blurring
- document new AfterImage blur parameter

## Testing
- `go test ./...` *(fails: Xcursor.h: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68929446c6f8832b8e3fbe3d9ff1d33c